### PR TITLE
Add travis.yml and build success indicator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 mbassador-spring
 ================
+[![Build Status](https://travis-ci.org/bennidi/mbassador-spring.svg?branch=master)](https://travis-ci.org/bennidi/mbassador-spring)
+
 CDI-like transactional events in Spring!
 
 Use MBassador in Spring environment. Supports conditional message dispatch (e.g. after or before {commit|rollback}) based


### PR DESCRIPTION
For ease of processing pull requests, here's the Travis CI config that'll allow Travis to build the project and show a build success indicator.

You can see it working for my fork at:
https://travis-ci.org/eccosolutions/mbassador-spring/branches 

You'll also need to merge in the fixes in pull #8 to get what's passing on my master build.

Cheers,

Neale